### PR TITLE
Updated the Dockerfile proxy settings to play nicely with UoA VMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,28 +4,29 @@ MAINTAINER      Sam Kavanagh "s.kavanagh@auckland.ac.nz"
 ARG             http_proxy
 ARG             https_proxy
 
-# Configure proxy for maven on UoA VMs
-RUN		        if [ "$http_proxy" != "" ]; then \
-		            proxy=$(basename $http_proxy); host=${proxy%:*}; port=${proxy#*:}; \
-		            echo "/opt/maven/bin/mvn -DproxySet=true -DproxyHost=$host -DproxyPort=$port \$*" >> /usr/local/bin/mvn; \
-		        else \
-		            echo "/opt/maven/bin/mvn \$*" >> /usr/local/bin/mvn; \
-		        fi
-
 ENV             MAVEN_HOME /opt/maven
-RUN             rm -f /apache-maven.tar.gz
 
 # Build cer api jar with maven
 WORKDIR         /cer-api/
 
 # Resolve dependencies with maven, stops maven from re-downloading dependencies
 COPY            /pom.xml /cer-api/pom.xml
-RUN             mvn dependency:go-offline
-RUN             mvn verify clean --fail-never
+
+# Configure proxy for maven on UoA vms
+RUN		if [ -z $http_proxy ]; then \
+			mvn dependency:go-offline; \
+			mvn verify clean --fail-never; \
+		else \
+			proxy=$(basename $http_proxy); host=${proxy%:*}; port=${proxy#*:}; \
+			export MAVEN_OPTS="-DproxySet=true -DproxyHost=$host -DproxyPort=$port"; \
+			echo $MAVEN_OPTS; \
+			mvn dependency:go-offline; \
+			mvn verify clean --fail-never; \
+		fi;
 
 # Copy src files and build project
 COPY            /src /cer-api/src
-RUN 		    mvn -o package
+RUN 		mvn -o package
 RUN             mv target/app.jar /app.jar
 
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.config.location=file:/application.properties","-jar","/app.jar"]


### PR DESCRIPTION
The updated Dockerfiles (using Maven as the base image) needed to have their proxy settings modified to work when running on UoA VMs. The old way of configuring the Maven proxy settings no longer worked.