### PR TITLE
Add ability to run the Hub locally for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-target/
 !.mvn/wrapper/maven-wrapper.jar
 
 ### STS ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ FROM		prepare	AS local
 
 # Create a user in the image that has the same UID as the host user and run the Docker image as the user, so that generated classfiles can be shared between host and image.
 ARG		current_uid
-RUN		useradd -m --uid $current_uid cerapi-user
-USER		cerapi-user
+RUN		useradd -m --uid $current_uid cerapi
+USER		cerapi
 
 # Mount source and generated classfile directories as volumes
 VOLUME		["/cer-api/src","/application.properties","/cer-api/target","/cer-api/pom.xml","/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ WORKDIR         /cer-api/
 FROM		prepare	AS local
 
 # Create a user in the image that has the same UID as the host user and run the Docker image as the user, so that generated classfiles can be shared between host and image.
-ARG		current_uid
-RUN		useradd -m --uid $current_uid cerapi
-USER		cerapi
+ARG		current_uid=1000  # Defaults to 1000 if not set in hub.env.
+RUN		useradd -m --uid $current_uid cerapi-user
+USER		cerapi-user
 
 # Mount source and generated classfile directories as volumes
 VOLUME		["/cer-api/src","/application.properties","/cer-api/target","/cer-api/pom.xml","/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR         /cer-api/
 FROM		prepare	AS local
 
 # Create a user in the image that has the same UID as the host user and run the Docker image as the user, so that generated classfiles can be shared between host and image.
-ARG		current_uid=1000  # Defaults to 1000 if not set in hub.env.
+# Default user id to 1000 if not set in hub.env.
+ARG		current_uid=1000
 RUN		useradd -m --uid $current_uid cerapi-user
 USER		cerapi-user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM            maven:3.5.4-jdk-8
+FROM            maven:3.5.4-jdk-8 AS prepare
 MAINTAINER      Sam Kavanagh "s.kavanagh@auckland.ac.nz"
 
 ARG             http_proxy
@@ -23,6 +23,16 @@ RUN		if [ -z $http_proxy ]; then \
 			mvn dependency:go-offline; \
 			mvn verify clean --fail-never; \
 		fi;
+
+# Local development stage.
+FROM		prepare	AS dev
+VOLUME		["/cer-api/src","/application.properties","/cer-api/target"]
+
+ENTRYPOINT ["mvn","spring-boot:run","-Drun.jvmArguments=-Dspring.config.location=/application.properties"]
+
+
+# Build stage.
+FROM		prepare	AS build
 
 # Copy src files and build project
 COPY            /src /cer-api/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR         /cer-api/
 
 # Resolve dependencies with maven, stops maven from re-downloading dependencies
 COPY            /pom.xml /cer-api/pom.xml
+COPY		/docker-entrypoint.sh /
 
 # Configure proxy for maven on UoA vms
 RUN		if [ -z $http_proxy ]; then \
@@ -26,9 +27,8 @@ RUN		if [ -z $http_proxy ]; then \
 
 # Local development stage.
 FROM		prepare	AS local
-VOLUME		["/cer-api/src","/application.properties","/cer-api/target"]
-
-ENTRYPOINT ["mvn","spring-boot:run","-Drun.jvmArguments=-Dspring.config.location=/application.properties"]
+VOLUME		["/cer-api/src","/application.properties","/cer-api/target","/cer-api/pom.xml"]
+ENTRYPOINT ["/docker-entrypoint.sh","--local"]
 
 
 # Build stage.
@@ -40,4 +40,4 @@ COPY            application.properties /
 RUN             mvn -o package
 RUN             mv target/app.jar /app.jar
 
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.config.location=file:/application.properties","-jar","/app.jar"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN		if [ -z $http_proxy ]; then \
 		fi;
 
 # Local development stage.
-FROM		prepare	AS dev
+FROM		prepare	AS local
 VOLUME		["/cer-api/src","/application.properties","/cer-api/target"]
 
 ENTRYPOINT ["mvn","spring-boot:run","-Drun.jvmArguments=-Dspring.config.location=/application.properties"]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ To deploy the CeR API follow the instructions on the [Research Hub Deploy projec
 
 To work on the Centre for eResearch REST API locally, follow the instructions on the [Research Hub Deploy project](https://github.com/UoA-eResearch/research-hub-deploy) on running the project locally.
 
-The instructions will run a Spring Boot Devtools instance inside a Docker container that [hotswaps project classfiles](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-hotswapping.html) (stored under the ՝/target՝ directory). See the ՝Dockerfile՝ for more detail.
+The instructions will run a Spring Boot Devtools instance inside a Docker container that [hotswaps project classfiles](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-hotswapping.html) (stored under the `/target` directory). See `Dockerfile` for more detail.
 
-You can then modify source code of the project, compile (either by running the command ՝mvn compile՝ or by using an IDE), and watch the changes get loaded by Spring Boot Devtools.
+You can then modify source code of the project, compile (either by running the command `mvn compile` or by using an IDE), and watch the changes get loaded by Spring Boot Devtools.
 
 The API is served on localhost:8081/cer-api/.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 The Centre for eResearch REST API.
 
 To deploy the CeR API follow the instructions on the [Research Hub Deploy project](https://github.com/UoA-eResearch/research-hub-deploy) and Nuclino.
+
+## Developing CeR API
+
+To work on the Centre for eResearch REST API locally, follow the instructions on the [Research Hub Deploy project](https://github.com/UoA-eResearch/research-hub-deploy) on running the project locally.
+
+The instructions will run a Spring Boot Devtools instance inside a Docker container that [hotswaps project classfiles](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-hotswapping.html) (stored under the ՝/target՝ directory). See the ՝Dockerfile՝ for more detail.
+
+You can then modify source code of the project, compile (either by running the command ՝mvn compile՝ or by using an IDE), and watch the changes get loaded by Spring Boot Devtools.
+
+The API is served on localhost:8081/cer-api/.

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
-server.port=80
+server.port=8080
 
 tomcat.ajp.port=9090
 tomcat.ajp.remote-authentication=false

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3.4'
 services:
   cer-api:
     image: ${DOCKER_REGISTRY_URI}/${DOCKER_IMAGE_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3.4'
 services:
   cer-api:
     build:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$1" == "--local" ]; then
+    # If the local flag is passed, we run a version of the cer api project set up for development.
+    # Run dependency to make sure new dependencies since last Docker build are installed.
+    mvn dependency:go-offline
+    mvn spring-boot:run -Drun.jvmArguments=-Dspring.config.location=/application.properties
+    exit
+fi
+
+java -Djava.security.egd=file:/dev/./urandom -Dspring.config.location=file:/application.properties -jar /app.jar

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,8 @@ if [ "$1" == "--local" ]; then
     # If the local flag is passed, we run a version of the cer api project set up for development.
     # Run dependency to make sure new dependencies since last Docker build are installed.
     mvn dependency:go-offline
+    # Run a version of spring boot which watches the /target directory, and reloads when
+    # generated classfiles change.
     mvn spring-boot:run -Drun.jvmArguments=-Dspring.config.location=/application.properties
     exit
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <scope>test</scope>
         </dependency>
 
+	<dependency>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-devtools</artifactId>
+		<optional>true</optional>
+	</dependency>
+
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,3 +1,21 @@
+# This file ensures when the repository is cloned,
+# this /target directory exists and is owned by the user
+# who clones the repository.
+# This is because /target is a Docker volume mounted
+# into the local development Docker image, so that
+# when we change the source, a host process
+# (e.g. mvn compile or an IDE) can compile and
+# generate changed classfiles, put them into this directory,
+# and the Docker image Maven process can detect and reload
+# the server process.
+# Docker creates an empty directory as root when a
+# volume does not exist on the host. (https://docs.docker.com/storage/)
+# So if this directory does not exist at the time of
+# running the local development Docker image,
+# a root-owned /target directory will be created by Docker.
+# This is not ideal as the host process would need to
+# be run by root in order to compile and generate classfiles.
+
 # Ignore everything in this directory
 *
 # Except this file


### PR DESCRIPTION
This is part of a Hub-wide feature to run the complete Hub locally for development. The changes in this repository will enable running the cer-api project locally with file-watching and hot-reloading, so that changes to the source code will cause compilation and reload.

The feature will be progressively merged into different repositories. See the deploy project branch for more information.